### PR TITLE
Docs/add vision

### DIFF
--- a/.copilot/vision.md
+++ b/.copilot/vision.md
@@ -106,10 +106,8 @@ Stima totale MVP Studio (Milestones B+C+D+tests): ~9–16 giorni (1 dev).
 ---
 
 ## 12 — Prossimi passi consigliati (operativi)
-1. Confermiamo questo testo.  
-2. Creiamo issue US-012 (MVP Studio) e TOOLS-001 (skeleton upload/job) basate su questo documento.  
-3. Scaffolding del branch feature/us-012-fretboard con parser stub e component skeleton per produrre la prima PR/preview.
+1. Creiamo issue US-012 (MVP Studio) e TOOLS-001 (skeleton upload/job) basate su questo documento.  
+2. Scaffolding del branch feature/us-012-fretboard con parser stub e component skeleton per produrre la prima PR/preview.
 
 ---
 
-Nota: questa è una bozza di vision collaborativa. Non verrà inserita nel repo finché non mi dai conferma. Quando confermi, la salvo in `.copilot/vision.md` in un branch `docs/add-vision` e apro la PR con link nella tua checklist.


### PR DESCRIPTION
Aggiunge bozza della vision del progetto in .copilot/vision.md. Manteniamo il prototipo attivo e pianifichiamo il refactor graduale.

Checklist / attività proposte:

    Review and approve Vision text
    Create issue: PROTOTYPE-001 - Preserve prototype snapshot and gh-pages demo
    Create issue: PROTOTYPE-002 - Fix critical HTML issues in the prototype
    Create issue: PROTOTYPE-003 - Add data-attributes and test hooks to prototype fretboard
    Create issue: PROTOTYPE-004 - Extract musical utilities into src/lib/music with tests
    Create issue: PROTOTYPE-005 - Accessibility improvements for fretboard table cells
    Create issue: PROTOTYPE-006 - Add Storybook stories for prototype views
    Create issue: PROTOTYPE-007 - Create LegacyFretboardShim for backward compatibility

Note:

    Questo PR aggiunge solo la bozza di Vision; non modifica codice di produzione.
    Si chiede review manuale prima del merge.
    Labels suggerite: docs
    PR lasciata aperta per review manuale (nessun reviewer assegnato).
